### PR TITLE
update ATL with fix for crash in MediaCodec

### DIFF
--- a/io.gitlab.android_translation_layer.BaseApp.yml
+++ b/io.gitlab.android_translation_layer.BaseApp.yml
@@ -265,7 +265,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/android_translation_layer/android_translation_layer.git
-        commit: ab07fc11da0b06b29ab38705ff932f2a10319c64
+        commit: bcdf3eb3ce0ea260d4bd2dd616e692b06caa7934
 
   - name: cacerts
     buildsystem: simple


### PR DESCRIPTION
Fix crash where the app crashes while trying to use h264 codec without ffmpeg-full being installed