### PR TITLE
Gtk picture redraw workaround

### DIFF
--- a/io.gitlab.android_translation_layer.BaseApp.yml
+++ b/io.gitlab.android_translation_layer.BaseApp.yml
@@ -266,6 +266,8 @@ modules:
       - type: git
         url: https://gitlab.com/android_translation_layer/android_translation_layer.git
         commit: d79df985c7e637fbddd72d5ad64a5db862a1c382
+      - type: patch
+        path: patches/gtk_picture_redraw_workaround.patch
 
   - name: cacerts
     buildsystem: simple

--- a/io.gitlab.android_translation_layer.BaseApp.yml
+++ b/io.gitlab.android_translation_layer.BaseApp.yml
@@ -254,7 +254,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/android_translation_layer/art_standalone.git
-        commit: eb1efc584ac5e803cecb79a760b5d682f3aa21c5
+        commit: eb04efa9aedda24061247c357689f0099daf0982
 
   - name: android-translation-layer
     buildsystem: meson
@@ -265,7 +265,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/android_translation_layer/android_translation_layer.git
-        commit: bcdf3eb3ce0ea260d4bd2dd616e692b06caa7934
+        commit: d79df985c7e637fbddd72d5ad64a5db862a1c382
 
   - name: cacerts
     buildsystem: simple

--- a/patches/gtk_picture_redraw_workaround.patch
+++ b/patches/gtk_picture_redraw_workaround.patch
@@ -1,0 +1,20 @@
+diff --git a/src/api-impl-jni/media/android_media_MediaCodec.c b/src/api-impl-jni/media/android_media_MediaCodec.c
+index 2754326a..74ab16f0 100644
+--- a/src/api-impl-jni/media/android_media_MediaCodec.c
++++ b/src/api-impl-jni/media/android_media_MediaCodec.c
+@@ -525,6 +525,7 @@ static gboolean render_frame(void *data)
+ #if GTK_CHECK_VERSION(4, 14, 0)
+ 	GdkTexture *texture = import_drm_frame_desc_as_texture(drm_frame_desc, drm_frame->width, drm_frame->height, drm_frame);
+ 	gtk_picture_set_paintable(d->gtk_picture, GDK_PAINTABLE(texture));
++	gtk_widget_queue_draw(GTK_WIDGET(d->gtk_picture));
+ 	g_object_unref(texture);
+ #else
+ 	struct wl_buffer *wl_buffer = import_drm_frame_desc(d->zwp_linux_dmabuf_v1,
+@@ -550,6 +551,7 @@ static gboolean render_texture(void *data) {
+ 	struct render_frame_data *d = (struct render_frame_data *)data;
+ 
+ 	gtk_picture_set_paintable(d->gtk_picture, GDK_PAINTABLE(d->texture));
++	gtk_widget_queue_draw(GTK_WIDGET(d->gtk_picture));
+ 	g_object_unref(d->texture);
+ 
+ 	free(d);


### PR DESCRIPTION
Workaround bug https://gitlab.gnome.org/GNOME/gtk/-/issues/7067 where GtkPicture doesn't redraw by itself.