### PR TITLE
Media codec and wolfssl fixes

### DIFF
--- a/io.gitlab.android_translation_layer.BaseApp.yml
+++ b/io.gitlab.android_translation_layer.BaseApp.yml
@@ -231,7 +231,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/android_translation_layer/bionic_translation.git
-        commit: e502e9273c5fb600751f53a1d843ad38c910b2d8
+        commit: 60f1f64de330e734c2476c51ac6aec67396a4781
 
   - name: art_standalone
     no-autogen: true
@@ -247,7 +247,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/android_translation_layer/art_standalone.git
-        commit: ce8fe1f089320a0d83c303661db4d2100119b053
+        commit: a1ea1c33d082e8ec70dcfae99c0a8d23246af700
 
   - name: android-translation-layer
     buildsystem: meson
@@ -258,7 +258,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/android_translation_layer/android_translation_layer.git
-        commit: fc0091a989bdb9f02854c5c0789d613f1b9096fb
+        commit: ab114245bd93706d219ad38658c76abf9451791b
       - type: patch
         path: patches/gtk_picture_redraw_workaround.patch
 

--- a/io.gitlab.android_translation_layer.BaseApp.yml
+++ b/io.gitlab.android_translation_layer.BaseApp.yml
@@ -206,18 +206,11 @@ modules:
       - --enable-scrypt
       - --disable-examples
       - --enable-crl
-      - --with-rsa
-      - --enable-certs
-      - --enable-session-certs
-      - --enable-encrypted-keys
-      - --enable-cert-gen
-      - --enable-cert-ext
-      - --enable-clr-monitor
       - --enable-jni
     sources:
       - type: git
         url: https://github.com/wolfSSL/wolfssl.git
-        tag: v5.7.0-stable
+        tag: v5.7.4-stable
 
   - name: vixl
     buildsystem: meson


### PR DESCRIPTION
The wolfSSL update includes a fix for certificates with more than 128 alt names. The ATL update includes some MediaCodec improvements

Fixes https://github.com/flathub/net.newpipe.NewPipe/issues/3