### PR TITLE
run dex2oat at buildtime

### DIFF
--- a/io.gitlab.android_translation_layer.BaseApp.yml
+++ b/io.gitlab.android_translation_layer.BaseApp.yml
@@ -107,6 +107,7 @@ modules:
       - type: git
         url: https://gitlab.com/android_translation_layer/bionic_translation.git
         commit: 028fb270a852f4791b522389d8899377bb824dcf
+        disable-submodules: true
 
   - name: art_standalone
     no-autogen: true


### PR DESCRIPTION
This should speed up initial app startup. The download size is minimal bigger, but cache size will be much smaller. Overall, less disk space will be used, because Flatpak-builder can now extract java debug info into a separate debug package.